### PR TITLE
make the error message clear when libvarnishapi-dev is missing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Varnish 4 vmod for loading maxminddb (geoip2)
 
 **I have no clue what I'm doing, will most likely be insecure.**
 
-
+Requirement:
+=================
+Packages: build-essential libtool libvarnishapi-dev python-docutils 
 
 Build:
 =================

--- a/m4/varnish.m4
+++ b/m4/varnish.m4
@@ -39,9 +39,9 @@ m4_pattern_allow([^VARNISH_VMOD(_INCLUDE_DIR|TOOL)$])
 PKG_CHECK_EXISTS([varnishapi],[],[
 	if test -n "$PKG_CONFIG"; then
 		AC_MSG_FAILURE(
-[The pkg-config script could not be found or is too old.  Make sure it
+[The pkg-config script could not be found or is too old or varnishapi is missing.  Make sure it
 is in your PATH or set the PKG_CONFIG environment variable to the full
-path to pkg-config.
+path to pkg-config and make sure the package libvarnishapi-dev is installed.
 
 To get pkg-config, see <http://pkg-config.freedesktop.org/>.])
 	else


### PR DESCRIPTION
make the error message clear when libvarnishapi-dev is missing. add the package requirement in readme
