### PR TITLE
Create 4.1 branch: Replace init_function with event_function

### DIFF
--- a/src/vmod_maxminddb.c
+++ b/src/vmod_maxminddb.c
@@ -7,6 +7,7 @@
 #include "vcc_if.h"
 #include "config.h"
 #include "vsa.h"
+#include "vcl.h"
 
 #include <maxminddb.h>
 
@@ -119,7 +120,7 @@ vmod_query(const struct vrt_ctx *ctx, struct vmod_priv *priv, const struct sucka
 }
 
 int
-init_function(struct vmod_priv *priv, const struct VCL_conf *conf)
+event_function(VRT_CTX, struct vmod_priv *priv, enum vcl_event_e e)
 {
 	return (0);
 }

--- a/src/vmod_maxminddb.vcc
+++ b/src/vmod_maxminddb.vcc
@@ -1,5 +1,5 @@
 $Module maxminddb 3 maxminddb
-$Init init_function
+$Event event_function
 $Function VOID   init_db(PRIV_VCL, STRING)
 $Function STRING query_continent(PRIV_VCL, IP)
 $Function STRING query_country(PRIV_VCL, IP)


### PR DESCRIPTION
I just had a little excursion with Varnish 4.1.x.
It seems like <code>$Init init_function</code> was replaced by <code>$Event event_function</code>.
Even thought I've no idea what the function is required for I replaced <code>init_function</code> with the new <code>event_function</code> and so far it seems to compile / work like a charm ;)
So to be compatible with Varnish 4.1.x. we need to introduce this fix, but as we should stay backward compatible too I suggest to create a version specific branch.

Cheers
Peter