### PR TITLE
Remove the unused event_function

### DIFF
--- a/src/vmod_maxminddb.c
+++ b/src/vmod_maxminddb.c
@@ -16,13 +16,19 @@
 
 #include "vcc_if.h"
 
-void
-freeit(void *data)
+static void
+myfree(VRT_CTX, void *data)
 {
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	MMDB_close(data);
 	free(data);
 }
 
+static const struct vmod_priv_methods mymethods[1] = {{
+	.magic = VMOD_PRIV_METHODS_MAGIC,
+	.type = "mmdb",
+	.fini = myfree
+}};
 
 int
 lookup(MMDB_s *db, const struct suckaddr *ip, MMDB_entry_data_s *entry, const char **path, uint32_t type)
@@ -55,15 +61,17 @@ lookup(MMDB_s *db, const struct suckaddr *ip, MMDB_entry_data_s *entry, const ch
 VCL_VOID
 vmod_init_db(const struct vrt_ctx *ctx, struct vmod_priv *priv, const char *filename)
 {
-	priv->priv = (MMDB_s *)calloc(1, sizeof(MMDB_s));
-	if (priv->priv == NULL)
-		return;
+
+	if (priv->priv == NULL) {
+	        priv->priv = (MMDB_s *)calloc(1, sizeof(MMDB_s));
+		AN(priv->priv);
+	        priv->methods = mymethods;
+	}
 
 	if(MMDB_open(filename, MMDB_MODE_MMAP, priv->priv) != MMDB_SUCCESS){
 		free(priv->priv);
 		return;
 	}
-	priv->free = freeit;
 }
 
 VCL_STRING

--- a/src/vmod_maxminddb.c
+++ b/src/vmod_maxminddb.c
@@ -159,9 +159,3 @@ vmod_query(const struct vrt_ctx *ctx, struct vmod_priv *priv, const struct sucka
 {
 	return vmod_query_country(ctx, priv, ip);
 }
-
-int
-event_function(VRT_CTX, struct vmod_priv *priv, enum vcl_event_e e)
-{
-	return (0);
-}

--- a/src/vmod_maxminddb.vcc
+++ b/src/vmod_maxminddb.vcc
@@ -1,6 +1,5 @@
 $Module maxminddb 3 maxminddb
 $ABI vrt
-$Event event_function
 $Function VOID   init_db(PRIV_VCL, STRING)
 $Function STRING query_continent(PRIV_VCL, IP)
 $Function STRING query_country(PRIV_VCL, IP)


### PR DESCRIPTION
Varnish 6 is expecting this function to be called vmod_event_function and fails to load the module:

Message from VCC-compiler:
Could not load VMOD maxminddb
        File name: /usr/local/lib/varnish/vmods/libvmod_maxminddb.so
        dlerror: /usr/local/lib/varnish/vmods/libvmod_maxminddb.so: Undefined symbol "vmod_event_function"


Removing it from the vcc seems better than renaming it to make it worse, since it doesn't DO anything.